### PR TITLE
Correct urls to be version neutral

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 This is the working area for the SACM working group internet-draft, "SACM Vulnerability Assessment Scenario".
 
 * [Editor's copy](https://sacmwg.github.io/vulnerability-scenario/draft-ietf-sacm-vuln-scenario.html)
-* [Individual Draft] (https://tools.ietf.org/html/draft-ietf-sacm-vuln-scenario-00)
-* [Compare Working Group and Editor's Drafts] (https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/id/draft-ietf-sacm-vuln-scenario-00.txt&url2=https://sacmwg.github.io/vulnerability-scenario/draft-ietf-sacm-vuln-scenario.txt)
+* [Individual Draft] (https://tools.ietf.org/html/draft-ietf-sacm-vuln-scenario)
+* [Compare Working Group and Editor's Drafts] (https://tools.ietf.org/rfcdiff?url1=https://www.ietf.org/id/draft-ietf-sacm-vuln-scenario&url2=https://sacmwg.github.io/vulnerability-scenario/draft-ietf-sacm-vuln-scenario.txt)
 
 ## Status
 


### PR DESCRIPTION
If we point to version neutral URLs then they do not need to be updated every time a new version of the document is published.
